### PR TITLE
feat: added banner and update subscription check to make maintained actions free for public repos

### DIFF
--- a/.github/workflows/actions_release.yml
+++ b/.github/workflows/actions_release.yml
@@ -6,6 +6,10 @@ on:
       tag:
         description: "Tag for the release"
         required: true
+      node_version:
+        description: "Specify Node.js version (e.g., '18', '20', 'lts/*')"
+        required: false
+        default: "24"
 
 permissions:
   contents: read
@@ -19,3 +23,4 @@ jobs:
     uses: step-security/reusable-workflows/.github/workflows/actions_release.yaml@v1
     with:
       tag: "${{ github.event.inputs.tag }}"
+      node_version: "${{ github.event.inputs.node_version }}"

--- a/.github/workflows/audit_package.yml
+++ b/.github/workflows/audit_package.yml
@@ -10,6 +10,10 @@ on:
         description: "Specify a base branch"
         required: false
         default: "main"
+      node_version:
+        description: "Specify Node.js version (e.g., '18', '20', 'lts/*')"
+        required: false
+        default: "24"
   schedule:
     - cron: "0 0 * * 1"
 
@@ -19,6 +23,7 @@ jobs:
     with:
       force: ${{ inputs.force || false }}
       base_branch: ${{ inputs.base_branch || 'main' }}
+      node_version: "${{ inputs.node_version || '24' }}"
 
 permissions:
   contents: write

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![StepSecurity Maintained Action](https://raw.githubusercontent.com/step-security/maintained-actions-assets/main/assets/maintained-action-banner.png)](https://docs.stepsecurity.io/actions/stepsecurity-maintained-actions)
+
 # Lua Environment Setup Action
 
 ### `step-security/gh-actions-lua`

--- a/dist/index.js
+++ b/dist/index.js
@@ -100142,23 +100142,52 @@ const exec = __nccwpck_require__(95236);
 const io = __nccwpck_require__(94994);
 const tc = __nccwpck_require__(33472);
 const ch = __nccwpck_require__(5116);
-const fs = (__nccwpck_require__(79896).promises);
+const fs = __nccwpck_require__(79896);
 const path = __nccwpck_require__(16928);
 
 async function validateSubscription() {
-  const API_URL = `https://agent.api.stepsecurity.io/v1/github/${process.env.GITHUB_REPOSITORY}/actions/subscription`;
+  let repoPrivate;
+  const eventPath = process.env.GITHUB_EVENT_PATH;
+  if (eventPath && fs.existsSync(eventPath)) {
+    const payload = JSON.parse(fs.readFileSync(eventPath, "utf8"));
+    repoPrivate = payload?.repository?.private;
+  }
 
+  const upstream = "leafo/gh-actions-lua";
+  const action = process.env.GITHUB_ACTION_REPOSITORY;
+  const docsUrl =
+    "https://docs.stepsecurity.io/actions/stepsecurity-maintained-actions";
+
+  core.info("");
+  core.info("[1;36mStepSecurity Maintained Action[0m");
+  core.info(`Secure drop-in replacement for ${upstream}`);
+  if (repoPrivate === false)
+    core.info("[32m✓ Free for public repositories[0m");
+  core.info(`[36mLearn more:[0m ${docsUrl}`);
+  core.info("");
+
+  if (repoPrivate === false) return;
+  const serverUrl = process.env.GITHUB_SERVER_URL || "https://github.com";
+  const body = { action: action || "" };
+
+  if (serverUrl !== "https://github.com") body.ghes_server = serverUrl;
   try {
-    await axios.get(API_URL, {timeout: 3000});
+    await axios.post(
+      `https://agent.api.stepsecurity.io/v1/github/${process.env.GITHUB_REPOSITORY}/actions/maintained-actions-subscription`,
+      body,
+      { timeout: 3000 },
+    );
   } catch (error) {
-    if (error.response && error.response.status === 403) {
-      console.error(
-        'Subscription is not valid. Reach out to support@stepsecurity.io'
+    if (axios.isAxiosError(error) && error.response?.status === 403) {
+      core.error(
+        `[1;31mThis action requires a StepSecurity subscription for private repositories.[0m`,
+      );
+      core.error(
+        `[31mLearn how to enable a subscription: ${docsUrl}[0m`,
       );
       process.exit(1);
-    } else {
-      core.info('Timeout or API not reachable. Continuing to next step.');
     }
+    core.info("Timeout or API not reachable. Continuing to next step.");
   }
 }
 
@@ -100200,7 +100229,7 @@ function getCurrentDirectory() {
 
 async function checkFileExists(filePath) {
   try {
-    await fs.access(filePath);
+    await fs.promises.access(filePath);
     return true;
   } catch {
     return false;
@@ -100220,11 +100249,11 @@ async function setupLuaJITSymlinks(sourceDir, installDir, binaryName) {
   const binDir = createPosixPath(installDir, "bin");
   
   if (os.isWindows) {
-    await fs.copyFile(
+    await fs.promises.copyFile(
       createPosixPath(sourceDir, "lua51.dll"),
       createPosixPath(installDir, "bin", "lua51.dll")
     );
-    await fs.copyFile(
+    await fs.promises.copyFile(
       createPosixPath(sourceDir, "lua51.dll"),
       createPosixPath(installDir, "lib", "lua51.dll")
     );
@@ -100298,7 +100327,7 @@ async function copyFiles(targetDir, sourceDir, fileList) {
   await io.mkdirP(targetDir);
   for (const file of fileList) {
     const fileName = path.posix.basename(file);
-    await fs.copyFile(createPosixPath(sourceDir, file), createPosixPath(targetDir, fileName));
+    await fs.promises.copyFile(createPosixPath(sourceDir, file), createPosixPath(targetDir, fileName));
   }
 }
 
@@ -100318,7 +100347,7 @@ async function buildLuaWindows(extractPath, installPath, version) {
   };
 
   const sourceDir = createPosixPath(extractPath, "src");
-  const files = await fs.readdir(sourceDir);
+  const files = await fs.promises.readdir(sourceDir);
 
   for (const file of files) {
     if (file.endsWith(".c")) {
@@ -100435,7 +100464,7 @@ async function main() {
   }
 
   if (cachedToolDir && !(await checkFileExists(installPath))) {
-    await fs.symlink(cachedToolDir, installPath);
+    await fs.promises.symlink(cachedToolDir, installPath);
   }
 
   core.addPath(createPosixPath(installPath, "bin"));

--- a/main.js
+++ b/main.js
@@ -4,23 +4,52 @@ const exec = require("@actions/exec");
 const io = require("@actions/io");
 const tc = require("@actions/tool-cache");
 const ch = require("@actions/cache");
-const fs = require("fs").promises;
+const fs = require("fs");
 const path = require("path");
 
 async function validateSubscription() {
-  const API_URL = `https://agent.api.stepsecurity.io/v1/github/${process.env.GITHUB_REPOSITORY}/actions/subscription`;
+  let repoPrivate;
+  const eventPath = process.env.GITHUB_EVENT_PATH;
+  if (eventPath && fs.existsSync(eventPath)) {
+    const payload = JSON.parse(fs.readFileSync(eventPath, "utf8"));
+    repoPrivate = payload?.repository?.private;
+  }
 
+  const upstream = "leafo/gh-actions-lua";
+  const action = process.env.GITHUB_ACTION_REPOSITORY;
+  const docsUrl =
+    "https://docs.stepsecurity.io/actions/stepsecurity-maintained-actions";
+
+  core.info("");
+  core.info("[1;36mStepSecurity Maintained Action[0m");
+  core.info(`Secure drop-in replacement for ${upstream}`);
+  if (repoPrivate === false)
+    core.info("[32m✓ Free for public repositories[0m");
+  core.info(`[36mLearn more:[0m ${docsUrl}`);
+  core.info("");
+
+  if (repoPrivate === false) return;
+  const serverUrl = process.env.GITHUB_SERVER_URL || "https://github.com";
+  const body = { action: action || "" };
+
+  if (serverUrl !== "https://github.com") body.ghes_server = serverUrl;
   try {
-    await axios.get(API_URL, {timeout: 3000});
+    await axios.post(
+      `https://agent.api.stepsecurity.io/v1/github/${process.env.GITHUB_REPOSITORY}/actions/maintained-actions-subscription`,
+      body,
+      { timeout: 3000 },
+    );
   } catch (error) {
-    if (error.response && error.response.status === 403) {
-      console.error(
-        'Subscription is not valid. Reach out to support@stepsecurity.io'
+    if (axios.isAxiosError(error) && error.response?.status === 403) {
+      core.error(
+        `[1;31mThis action requires a StepSecurity subscription for private repositories.[0m`,
+      );
+      core.error(
+        `[31mLearn how to enable a subscription: ${docsUrl}[0m`,
       );
       process.exit(1);
-    } else {
-      core.info('Timeout or API not reachable. Continuing to next step.');
     }
+    core.info("Timeout or API not reachable. Continuing to next step.");
   }
 }
 
@@ -62,7 +91,7 @@ function getCurrentDirectory() {
 
 async function checkFileExists(filePath) {
   try {
-    await fs.access(filePath);
+    await fs.promises.access(filePath);
     return true;
   } catch {
     return false;
@@ -82,11 +111,11 @@ async function setupLuaJITSymlinks(sourceDir, installDir, binaryName) {
   const binDir = createPosixPath(installDir, "bin");
   
   if (os.isWindows) {
-    await fs.copyFile(
+    await fs.promises.copyFile(
       createPosixPath(sourceDir, "lua51.dll"),
       createPosixPath(installDir, "bin", "lua51.dll")
     );
-    await fs.copyFile(
+    await fs.promises.copyFile(
       createPosixPath(sourceDir, "lua51.dll"),
       createPosixPath(installDir, "lib", "lua51.dll")
     );
@@ -160,7 +189,7 @@ async function copyFiles(targetDir, sourceDir, fileList) {
   await io.mkdirP(targetDir);
   for (const file of fileList) {
     const fileName = path.posix.basename(file);
-    await fs.copyFile(createPosixPath(sourceDir, file), createPosixPath(targetDir, fileName));
+    await fs.promises.copyFile(createPosixPath(sourceDir, file), createPosixPath(targetDir, fileName));
   }
 }
 
@@ -180,7 +209,7 @@ async function buildLuaWindows(extractPath, installPath, version) {
   };
 
   const sourceDir = createPosixPath(extractPath, "src");
-  const files = await fs.readdir(sourceDir);
+  const files = await fs.promises.readdir(sourceDir);
 
   for (const file of files) {
     if (file.endsWith(".c")) {
@@ -297,7 +326,7 @@ async function main() {
   }
 
   if (cachedToolDir && !(await checkFileExists(installPath))) {
-    await fs.symlink(cachedToolDir, installPath);
+    await fs.promises.symlink(cachedToolDir, installPath);
   }
 
   core.addPath(createPosixPath(installPath, "bin"));


### PR DESCRIPTION
## Summary

- Added StepSecurity Maintained Action banner to README.md
- Updated subscription validation: public repositories are now free (no API check)
- Upgraded Node.js runtime to node24 (if applicable)
- Updated workflow files with configurable node_version input (if applicable)

## Changes by type
- **TypeScript/JS actions**: replaced `validateSubscription()` body, updated action.yml to node24, updated 3 workflow files, rebuilt dist/
- **Docker actions**: replaced entrypoint.sh subscription block, ensured jq is installed in Dockerfile
- **Composite actions**: added Subscription check step to action.yml

## Verification
- [ ] Subscription check skips for public repos
- [ ] Subscription check fires for private repos
- [ ] README banner is present at the top
- [ ] Build passes (TS/JS actions)

Auto-generated by StepSecurity update-propagator. Task ID: 20260423T092801Z